### PR TITLE
Add the channels mod with a command for mods to change player's channels.

### DIFF
--- a/mods/channels/README.md
+++ b/mods/channels/README.md
@@ -1,0 +1,25 @@
+channels
+========
+
+License: WTFPL
+
+
+This modification for Minetest adds a channel feature.
+You can join and leave channels to create:
+- Teamchats
+- Silence because nobody else in the chat
+- Ignoring people
+- Annoy people which think, you are evil because you don't answer
+
+How to use
+----------
+
+There is one chat command to manage everything.
+
+
+Online players in your channel:  /channel online
+
+Join or switch your channel:     /channel set <channel>
+
+Leave the current channel:       /channel leave
+

--- a/mods/channels/chatcommands.lua
+++ b/mods/channels/chatcommands.lua
@@ -1,0 +1,146 @@
+minetest.register_chatcommand("change-player-channel", {
+	description = "Manages chat channels",
+	privs = {basic_privs = true},
+	func = function(name, param)
+		local player_name, to_channel = string.match(param, "([^ ]+) (.+)")
+		if not player_name then
+			return false, "Player does not exist!"
+		elseif not to_channel then
+			return false, "Channel not specified!"
+		end
+		channels.command_set(player_name, to_channel)
+		return true, player_name .. " moved to channel " .. to_channel .. "!"
+	end,
+})
+
+minetest.register_chatcommand("channel", {
+	description = "Manages chat channels",
+	privs = {
+		interact = true, 
+		shout = true
+	},
+	func = function(name, param)
+		if param == "" then
+			minetest.chat_send_player(name, "Online players: /channel online")
+			minetest.chat_send_player(name, "Join/switch:    /channel set <channel>")
+			minetest.chat_send_player(name, "Leave channel:  /channel leave")
+			return
+		elseif param == "online" then
+			channels.command_online(name)
+			return
+		elseif param == "leave" then
+			channels.command_leave(name)
+			return
+		end
+		local args = param:split(" ")
+		if args[1] == "set" then
+			if #args >= 2 then
+				 channels.command_set(name, args[2])
+				 return
+			end
+		end
+		minetest.chat_send_player(name, "Error: Please check again '/channel' for correct usage.")
+	end,
+})
+
+function channels.say_chat(name, message, channel)
+	for k,v in pairs(channels.players) do
+		if v == channel and k ~= name then
+			minetest.chat_send_player(k, message)
+		end
+	end
+end
+
+function channels.command_online(name)
+	local channel = channels.players[name]
+	local players = "You"
+	if channel then
+		for k,v in pairs(channels.players) do
+			if v == channel and k ~= name then
+				players = players..", "..k
+			end
+		end
+	else
+		local oplayers = minetest.get_connected_players()
+		for _,player in ipairs(oplayers) do
+			local p_name = player:get_player_name()
+			if not channels.players[p_name] and p_name ~= name then
+				players = players..", "..p_name
+			end
+		end
+		return
+	end
+	
+	minetest.chat_send_player(name, "Online players in this channel: "..players)
+end
+
+function channels.command_set(name, param)
+	if param == "" then
+		minetest.chat_send_player(name, "Error: Empty channel name")
+		return
+	end
+	
+	local channel_old = channels.players[name]
+	if channel_old then
+		if channel_old == param then
+			minetest.chat_send_player(name, "Error: You are already in this channel")
+			return
+		end
+		channels.say_chat(name, "# "..name.." left the channel", channel_old)
+	else
+		local oplayers = minetest.get_connected_players()
+		for _,player in ipairs(oplayers) do
+			local p_name = player:get_player_name()
+			if not channels.players[p_name] and p_name ~= name then
+				minetest.chat_send_player(p_name, "# "..name.." left the global chat")
+			end
+		end
+	end
+	
+	local player = minetest.get_player_by_name(name)
+	if not player then
+		return
+	end
+	
+	if channels.huds[name] then
+		player:hud_remove(channels.huds[name])
+	end
+	
+	channels.players[name] = param
+	channels.huds[name] = player:hud_add({
+		hud_elem_type	= "text",
+		name		= "Channel",
+		number		= 0xFFFFFF,
+		position = {x=0, y=1},
+		offset = {x=5, y=-85},
+		direction = 0,
+		text		= "Channel: "..param,
+		scale = {x=200, y=60},
+		alignment = {x=1, y=1},
+	})
+	channels.say_chat("", "# "..name.." joined the channel", param)
+end
+
+function channels.command_leave(name)
+	local player = minetest.get_player_by_name(name)
+	if not player then
+		channels.players[name] = nil
+		channels.huds[name] = nil
+		return
+	end
+	
+	if not (channels.players[name] and channels.huds[name]) then
+		minetest.chat_send_player(name, "Please join a channel first to leave it")
+		return
+	end
+	
+	if channels.players[name] then
+		channels.say_chat("", "# "..name.." left the channel", channels.players[name])
+		channels.players[name] = nil
+	end
+	
+	if channels.huds[name] then
+		player:hud_remove(channels.huds[name])
+		channels.huds[name] = nil
+	end
+end

--- a/mods/channels/init.lua
+++ b/mods/channels/init.lua
@@ -1,0 +1,25 @@
+channels = {}
+channels.huds = {}
+channels.players = {}
+
+dofile(minetest.get_modpath("channels").."/chatcommands.lua")
+
+minetest.register_on_chat_message(function(name, message)
+	local pl_channel = channels.players[name]
+	if not pl_channel then
+		return false
+	end
+	if pl_channel == "" then
+		channels.players[name] = nil
+		return false
+	end
+	
+	channels.say_chat(name, "<"..name.."> "..message, pl_channel)
+	return true
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	local name = player:get_player_name()
+	channels.players[name] = nil
+	channels.huds[name] = nil
+end)


### PR DESCRIPTION
Code from https://github.com/SmallJoker/channels

Brief summary:
Players can join channels and leave them, as they wish. When in a channel, players can see what is said by players who are not in a channel, but players not in a channel cannot see what players who are in channels say.

I added a command that allows mods to move players into a channel, for use when players are "dating" and such on the server... They can still leave the channel, if they wish, but it could act as a first step before shout is revoked.
