### PR TITLE
Fix couple of unknown homedecor craft recipes with alias & duplicated recipe for compressed cobble & darkage stone brick

### DIFF
--- a/mods/_misc/craft_fix.lua
+++ b/mods/_misc/craft_fix.lua
@@ -1,0 +1,25 @@
+minetest.register_alias("technic:motor", "homedecor:motor")
+minetest.register_alias("technic:slab_marble_1", "darkage:slab_marble_1")
+minetest.register_alias("technic:slab_granite_1", "default:gravel")
+
+minetest.register_alias("xpanes:pane", "default:glass")
+
+minetest.register_alias("cotton:black", "wool:black")
+minetest.register_alias("cotton:red", "wool:red")
+minetest.register_alias("cotton:blue", "wool:blue")
+minetest.register_alias("cotton:yellow", "wool:yellow")
+
+minetest.register_alias("building_blocks:gravel_spread", "default:gravel")
+minetest.register_alias("building_blocks:hardwood", "default:wood")
+minetest.register_alias("building_blocks:slab_hardwood", "default:wood")
+minetest.register_alias("building_blocks:sticks", "default:stick")
+minetest.register_alias("building_blocks:terrycloth_towel", "wool:white")
+minetest.register_alias("building_blocks:woodglass", "default:glass")
+minetest.register_alias("building_blocks:slab_marble", "darkage:slab_marble")
+minetest.register_alias("building_blocks:grate", "default:steelblock")
+
+minetest.register_alias("homedecor:table_lamp_off", "homedecor:table_lamp_white_off")
+minetest.register_alias("homedecor:standing_lamp_off", "homedecor:standing_lamp_white_off")
+
+minetest.register_alias("chains:chain_top_brass", "homedecor:chainlink_brass")
+

--- a/mods/_misc/craft_fix.lua
+++ b/mods/_misc/craft_fix.lua
@@ -23,3 +23,11 @@ minetest.register_alias("homedecor:standing_lamp_off", "homedecor:standing_lamp_
 
 minetest.register_alias("chains:chain_top_brass", "homedecor:chainlink_brass")
 
+minetest.register_craft({
+	output = "moreblocks:cobble_compressed",
+	recipe = {
+		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"},
+		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"},
+		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"}
+	}
+})

--- a/mods/_misc/init.lua
+++ b/mods/_misc/init.lua
@@ -22,3 +22,6 @@ dofile(minetest.get_modpath("_misc").."/legacy.lua")
 
 -- MOTD
 dofile(minetest.get_modpath("_misc").."/motd.lua")
+
+-- Cactus & Papyrus
+dofile(minetest.get_modpath("_misc").."/craft_fix.lua")

--- a/mods/_misc/init.lua
+++ b/mods/_misc/init.lua
@@ -23,5 +23,5 @@ dofile(minetest.get_modpath("_misc").."/legacy.lua")
 -- MOTD
 dofile(minetest.get_modpath("_misc").."/motd.lua")
 
--- Cactus & Papyrus
+-- Fix crafts
 dofile(minetest.get_modpath("_misc").."/craft_fix.lua")

--- a/mods/moreblocks/crafting.lua
+++ b/mods/moreblocks/crafting.lua
@@ -418,6 +418,7 @@ minetest.register_craft({
 	}
 })
 
+--[[
 minetest.register_craft({
 	output = "moreblocks:cobble_compressed",
 	recipe = {
@@ -426,6 +427,7 @@ minetest.register_craft({
 		{"default:cobble", "default:cobble", "default:cobble"},
 	}
 })
+]]
 
 minetest.register_craft({
 	output = "default:cobble 9",


### PR DESCRIPTION
Addresses #42 & remove the need for #68 since these alias will cover any future homedecor updates too.