### PR TITLE
Allow setting of motd ingame

### DIFF
--- a/mods/_misc/motd.lua
+++ b/mods/_misc/motd.lua
@@ -1,4 +1,23 @@
+local mod_storage = minetest.get_mod_storage()
+
+minetest.register_chatcommand("motd", {
+	description = "Message of the day.",
+	func = function(name, param)
+		if param == "" then
+		local motd = mod_storage:get_string("motd")
+			if motd then
+				minetest.chat_send_player(name, motd)
+			end
+		elseif param ~= "" and minetest.check_player_privs(name, {server=true}) then
+			mod_storage:set_string("motd", param)
+			minetest.chat_send_player(name, "Message of the day has been set to: "..param)
+		end
+	end,
+})
+ 
 minetest.register_on_joinplayer(function(player)
-	local message = "# Server: Skins & Sethome have recently been removed from the inventory. Use the commands /skin, /sethome and /home."
-	minetest.chat_send_player(player:get_player_name(), message)
+	local motd = mod_storage:get_string("motd")
+	if motd then
+		minetest.chat_send_player(player:get_player_name(), motd)
+	end
 end)


### PR DESCRIPTION
This makes use of mod storage.

Allow it so that, the repo doesn't have to be modified anytime you want to change the motd.
Only players with "server" privs can set motd.
Set motd with "/motd  `<message>`"

Normal players can view motd again by using "/motd".