### PR TITLE
Fix: Recipe fix for skeleton key

### DIFF
--- a/mods/craig_server/craft_fix.lua
+++ b/mods/craig_server/craft_fix.lua
@@ -33,15 +33,6 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "moreblocks:cobble_compressed",
-	recipe = {
-		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"},
-		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"},
-		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"}
-	}
-})
-
-minetest.register_craft({
 	output = 'default:skeleton_key',
 	recipe = {
 		{'default:gold_ingot', 'default:gold_ingot'},

--- a/mods/craig_server/craft_fix.lua
+++ b/mods/craig_server/craft_fix.lua
@@ -31,3 +31,19 @@ minetest.register_craft({
 		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"}
 	}
 })
+
+minetest.register_craft({
+	output = "moreblocks:cobble_compressed",
+	recipe = {
+		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"},
+		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"},
+		{"darkage:stone_brick", "darkage:stone_brick", "darkage:stone_brick"}
+	}
+})
+
+minetest.register_craft({
+	output = 'default:skeleton_key',
+	recipe = {
+		{'default:gold_ingot', 'default:gold_ingot'},
+	}
+})


### PR DESCRIPTION
Skeleton key is crafted using a single gold ingot.
Currently that is overridden by a bitcoin.
So I just added an additional recipe for it. 2 gold ingots.