### PR TITLE
Fix: Remove protection check for farm soil when placing seeds

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -41,10 +41,10 @@ farming.hoe_on_use = function(itemstack, user, pointed_thing, uses)
 		return
 	end
 
-	if minetest.is_protected(pt.under, user:get_player_name()) then
+	--[[if minetest.is_protected(pt.under, user:get_player_name()) then
 		minetest.record_protection_violation(pt.under, user:get_player_name())
 		return
-	end
+	end]]
 	if minetest.is_protected(pt.above, user:get_player_name()) then
 		minetest.record_protection_violation(pt.above, user:get_player_name())
 		return


### PR DESCRIPTION
Currently, when a seed is placed, two nodes are checked for protection, the area where the crop is placed and the soil underneath it.
It's completely useless to check the soil underneath it since any normal person who wants a protected farm would just protect the entire thing, not just the soil.

On the other hand, public farms function entirely using the above method, only the protection of the soil.
Without this check removed, there's no good way to protect a public farm, such that it wouldn't be prone to griefing.