### PR TITLE
Fix: Improved stairplus recipes

### DIFF
--- a/mods/moreblocks/stairsplus/recipes.lua
+++ b/mods/moreblocks/stairsplus/recipes.lua
@@ -303,7 +303,8 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 		})
 
 		minetest.register_alias(modname .. ":micro_" .. subname .. "_bottom", modname .. ":micro_" .. subname)
-	--[[elseif category == "panel" and alternate == "" then
+		
+	elseif category == "panel" and alternate == "" then
 		minetest.register_craft({
 			output = modname .. ":panel_" .. subname .. " 12",
 			recipe = {
@@ -325,12 +326,14 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 			output = modname .. ":panel_" .. subname,
 			recipe = {modname .. ":micro_" .. subname, modname .. ":micro_" .. subname},
 		})
-
+		
+		--[[
 		minetest.register_craft({
 			type = "shapeless",
 			output = recipeitem,
 			recipe = {modname .. ":panel_" .. subname, modname .. ":panel_" .. subname, modname .. ":panel_" .. subname, modname .. ":panel_" .. subname},
-		})
+		}) 
+		--]]
 
 		minetest.register_alias(modname.. ":panel_" ..subname.. "_bottom", modname.. ":panel_" ..subname)
 	elseif category == "slab" then
@@ -368,13 +371,12 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				},
 			})
 			------------------------------
-
 			minetest.register_craft({
 				type = "shapeless",
 				output = recipeitem,
 				recipe = {modname .. ":slab_" .. subname, modname .. ":slab_" .. subname},
 			})
-
+			
 			minetest.register_craft({
 				type = "shapeless",
 				output = modname .. ":slab_" .. subname .. " 3",
@@ -417,6 +419,7 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				recipe =  {modname .. ":slope_" .. subname .. "_outer_cut_half", modname .. ":slope_" .. subname .. "_inner_cut_half"},
 			})
 		elseif alternate == "_quarter" then
+			--[[
 			minetest.register_craft({
 				type = "shapeless",
 				output = recipeitem,
@@ -428,6 +431,7 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				output = recipeitem,
 				recipe = {modname .. ":slab_" .. subname .. "_three_quarter", modname .. ":slab_" .. subname .. "_quarter"},
 			})
+			--]]
 
 			minetest.register_craft({
 				type = "shapeless",
@@ -459,7 +463,7 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				recipe = {modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2"},
 			})
 		elseif alternate == "_2" then
-			minetest.register_craft({
+			--[[minetest.register_craft({
 				type = "shapeless",
 				output = recipeitem,
 				recipe = {modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2"},
@@ -469,7 +473,7 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				type = "shapeless",
 				output = recipeitem,
 				recipe = {modname .. ":slab_" .. subname .. "_14", modname .. ":slab_" .. subname .. "_2"},
-			})
+			})]]
 
 			minetest.register_craft({
 				type = "shapeless",
@@ -489,11 +493,13 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				recipe = {modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2", modname .. ":slab_" .. subname .. "_2"},
 			})
 		elseif alternate == "_15" then
+			--[[
 			minetest.register_craft({
 				type = "shapeless",
 				output = recipeitem,
 				recipe = {modname .. ":slab_" .. subname .. "_15", modname .. ":slab_" .. subname .. "_1"},
 			})
+			--]]
 
 			minetest.register_craft({
 				type = "shapeless",
@@ -509,6 +515,7 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				recipe =  {modname .. ":slope_" .. subname, modname .. ":slope_" .. subname},
 			})
 		elseif alternate == "_half" then
+			--[[
 			minetest.register_craft({
 				type = "shapeless",
 				output = recipeitem,
@@ -521,6 +528,8 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				recipe =  {modname .. ":slope_" .. subname .. "_half", modname .. ":slope_" .. subname .. "_half",
 					modname .. ":slope_" .. subname .. "_half", modname .. ":slope_" .. subname .. "_half"},
 			})
+			--]]
+		--[[
 		elseif alternate == "_outer" then
 			minetest.register_craft({
 				type = "shapeless",
@@ -557,6 +566,7 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 				output = recipeitem,
 				recipe =  {modname .. ":slope_" .. subname .. "_cut", modname .. ":slope_" .. subname .. "_cut"},
 			})
+		--]]
 		elseif alternate == "_half_raised" then
 			minetest.register_craft({
 				type = "shapeless",
@@ -684,6 +694,6 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 					{modname .. ":panel_" .. subname, ""},
 				},
 			})
-		end]]
+		end
 	end
 end

--- a/mods/moreblocks/stairsplus/recipes.lua
+++ b/mods/moreblocks/stairsplus/recipes.lua
@@ -10,44 +10,290 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 	if category == "micro" and alternate == "" then
 		minetest.register_craft({
 			type = "shapeless",
-			output = modname .. ":micro_" .. subname .. " 7",
-			recipe = {modname .. ":stair_" .. subname .. "_inner"},
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. "_1"},
 		})
 
 		minetest.register_craft({
 			type = "shapeless",
-			output = modname .. ":micro_" .. subname .. " 6",
-			recipe = {modname .. ":stair_" .. subname},
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":panel_" .. subname .. "_1"},
 		})
-
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. "_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":panel_" .. subname .. "_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. "_4"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":panel_" .. subname .. "_4"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":micro_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":panel_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":micro_" .. subname .. "_12"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":panel_" .. subname .. "_12"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":micro_" .. subname .. "_14"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":panel_" .. subname .. "_14"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":micro_" .. subname .. "_15"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":panel_" .. subname .. "_15"},
+		})
+		
 		minetest.register_craft({
 			type = "shapeless",
 			output = modname .. ":micro_" .. subname .. " 5",
 			recipe = {modname .. ":stair_" .. subname .. "_outer"},
 		})
-
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":stair_" .. subname .. ""},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":stair_" .. subname .. "_inner"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slab_" .. subname .. "_1"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slab_" .. subname .. "_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slab_" .. subname .. "_quarter"},
+		})
+		
 		minetest.register_craft({
 			type = "shapeless",
 			output = modname .. ":micro_" .. subname .. " 4",
-			recipe = {modname .. ":slab_" .. subname},
+			recipe = {modname .. ":slab_" .. subname .. ""},
 		})
-
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":slab_" .. subname .. "_three_quarter"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slab_" .. subname .. "_14"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 8",
+			recipe = {modname .. ":slab_" .. subname .. "_15"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slab_" .. subname .. "_two_sides"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slab_" .. subname .. "_three_sides"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slab_" .. subname .. "_three_sides_u"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":stair_" .. subname .. "_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":stair_" .. subname .. "_alt_1"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":stair_" .. subname .. "_alt_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":stair_" .. subname .. "_alt_4"},
+		})
+		
 		minetest.register_craft({
 			type = "shapeless",
 			output = modname .. ":micro_" .. subname .. " 4",
 			recipe = {modname .. ":stair_" .. subname .. "_alt"},
 		})
-
+		
 		minetest.register_craft({
 			type = "shapeless",
-			output = modname .. ":micro_" .. subname .. " 3",
-			recipe = {modname .. ":stair_" .. subname .. "_right_half"},
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":slope_" .. subname .. ""},
 		})
-
+		
 		minetest.register_craft({
 			type = "shapeless",
 			output = modname .. ":micro_" .. subname .. " 2",
-			recipe = {modname .. ":panel_" .. subname},
+			recipe = {modname .. ":slope_" .. subname .. "_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":slope_" .. subname .. "_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slope_" .. subname .. "_inner"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_cut"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_cut_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 8",
+			recipe = {modname .. ":slope_" .. subname .. "_inner_cut_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":slope_" .. subname .. "_outer"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_cut"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_cut_half"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 3",
+			recipe = {modname .. ":slope_" .. subname .. "_outer_cut_half_raised"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 4",
+			recipe = {modname .. ":slope_" .. subname .. "_cut"},
 		})
 
 		minetest.register_craft({
@@ -57,7 +303,7 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 		})
 
 		minetest.register_alias(modname .. ":micro_" .. subname .. "_bottom", modname .. ":micro_" .. subname)
-	elseif category == "panel" and alternate == "" then
+	--[[elseif category == "panel" and alternate == "" then
 		minetest.register_craft({
 			output = modname .. ":panel_" .. subname .. " 12",
 			recipe = {
@@ -438,6 +684,6 @@ stairsplus.register_recipes = function(category, alternate, modname, subname, re
 					{modname .. ":panel_" .. subname, ""},
 				},
 			})
-		end
+		end]]
 	end
 end


### PR DESCRIPTION
This commit adds the ability to convert any and every stairplus shape back into microblocks - ensuring that no blocks will be wasted - this wasn't possible before with odder shapes, like the slope and its variants.
The amount microblocks recycled is consistent with the cost to make it in the circular saw - so there will be no duplication.

At the same time, this removes the need to have a ton of complex recipes to convert the shapes back to blocks, everything can be converted into microblocks which can then be converted back into blocks.
With the exception of a few obvious recipe being kept - slab+slab / slope+slope / 8 microblocks.
The result of which is a much less flooded recipe list;

BEFORE:
![recipeflood1](https://user-images.githubusercontent.com/3191240/52529619-d57d9200-2d2f-11e9-8df7-3baedd8517f3.PNG)

AFTER:
![recipeflood2](https://user-images.githubusercontent.com/3191240/52529622-dd3d3680-2d2f-11e9-9f39-95b5fae3b4ed.PNG)

