### PR TITLE
Feature: Grant admin access into shared/dropbox/cobble locked chests

### DIFF
--- a/mods/more_chests/cobble.lua
+++ b/mods/more_chests/cobble.lua
@@ -1,5 +1,7 @@
-local function has_locked_chest_privilege(meta, player)
-	if player:get_player_name() ~= meta:get_string("owner") then
+local function has_locked_chest_privilege(meta, player, pos)
+	if default.can_interact_with_node(player, pos) then
+		return true
+	elseif player:get_player_name() ~= meta:get_string("owner") then
 		return false
 	end
 	return true
@@ -57,7 +59,7 @@ minetest.register_node("more_chests:cobble", {
 	end,
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a locked chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -68,7 +70,7 @@ minetest.register_node("more_chests:cobble", {
 	end,
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a locked chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -79,7 +81,7 @@ minetest.register_node("more_chests:cobble", {
 	end,
     allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a locked chest belonging to "..
 					meta:get_string("owner").." at "..

--- a/mods/more_chests/dropbox.lua
+++ b/mods/more_chests/dropbox.lua
@@ -1,5 +1,7 @@
-local function has_locked_chest_privilege(meta, player)
-	if player:get_player_name() ~= meta:get_string("owner") then
+local function has_locked_chest_privilege(meta, player, pos)
+	if default.can_interact_with_node(player, pos) then
+		return true
+	elseif player:get_player_name() ~= meta:get_string("owner") then
 		return false
 	end
 	return true
@@ -58,7 +60,7 @@ minetest.register_node("more_chests:dropbox", {
 	end,
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a dropbox belonging to "..
 					meta:get_string("owner").." at "..
@@ -69,7 +71,7 @@ minetest.register_node("more_chests:dropbox", {
 	end,
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if has_locked_chest_privilege(meta, player) then
+		if has_locked_chest_privilege(meta, player, pos) then
 			return stack:get_count()
 		end
 		local target = meta:get_inventory():get_list(listname)[index]

--- a/mods/more_chests/shared.lua
+++ b/mods/more_chests/shared.lua
@@ -1,10 +1,11 @@
-local function has_locked_chest_privilege(meta, player)
+local function has_locked_chest_privilege(meta, player, pos)
 	local name = player:get_player_name()
 	local shared = " "..meta:get_string("shared").." "
 	if name == meta:get_string("owner") then
 		return true
 	elseif shared:find(" "..name.." ") then
-
+		return true
+	elseif default.can_interact_with_node(player, pos) then
 		return true
 	else
 		return false
@@ -70,7 +71,7 @@ minetest.register_node("more_chests:shared", {
 	end,
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a shared chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -81,7 +82,7 @@ minetest.register_node("more_chests:shared", {
 	end,
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a shared chest belonging to "..
 					meta:get_string("owner").." at "..
@@ -92,7 +93,7 @@ minetest.register_node("more_chests:shared", {
 	end,
     allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
+		if not has_locked_chest_privilege(meta, player, pos) then
 			minetest.log("action", player:get_player_name()..
 					" tried to access a shared chest belonging to "..
 					meta:get_string("owner").." at "..


### PR DESCRIPTION
As title says, this change allows admins to access said more chests.
This ensure ease when there concerns events which deals with extracting nodes from such locked inventories.
The only chest which this feature is not applied is the secret chest, which I thought should stay true to its name after all.