### PR TITLE
Fix: Remove new formspec code

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -13,7 +13,6 @@ minetest.register_on_joinplayer(function(player)
 	player:set_formspec_prepend([[
 			bgcolor[#080808BB;true]
 			background[5,5;1,1;gui_formbg.png;true]
-			background[5,5;1,1;gui_formbg.png;true;10]
 			listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF] ]])
 end)
 


### PR DESCRIPTION
Latest formspec code isnt compatible with the minetest version that craig server is running on.
Was planning to just comment it out, but looks like the code is contained, so i have to remove it entirely. 