### PR TITLE
Feature: Readd some old default fences

### DIFF
--- a/mods/craig_server/depends.txt
+++ b/mods/craig_server/depends.txt
@@ -1,1 +1,2 @@
 sfinv
+default

--- a/mods/craig_server/init.lua
+++ b/mods/craig_server/init.lua
@@ -25,3 +25,6 @@ dofile(minetest.get_modpath("craig_server").."/spawn.lua")
 
 -- Fix main inventory (incompatible with sinv)
 dofile(minetest.get_modpath("craig_server").."/main_inv_fix.lua")
+
+-- Readd some old fences that were removed in latest git
+dofile(minetest.get_modpath("craig_server").."/old_fences.lua")

--- a/mods/craig_server/old_fences.lua
+++ b/mods/craig_server/old_fences.lua
@@ -1,0 +1,47 @@
+default.register_fence(":default:fence_cobble", {
+ 	description = "Cobbblestone Fence",
+ 	texture = "default_cobble.png",
+ 	material = "default:cobble",
+ 	groups = {cracky=3, stone=2},
+ 	sounds = default.node_sound_stone_defaults()
+ })
+
+ default.register_fence(":default:fence_desert_cobble", {
+ 	description = "Desert Cobbblestone Fence",
+ 	texture = "default_desert_cobble.png",
+ 	material = "default:desert_cobble",
+ 	groups = {cracky=3, stone=2},
+ 	sounds = default.node_sound_stone_defaults()
+ })
+
+ default.register_fence(":default:fence_sandstone", {
+ 	description = "Sandstone Fence",
+ 	texture = "default_sandstone.png",
+ 	material = "default:sandstone",
+ 	groups = {cracky=3, crumbly=2},
+ 	sounds = default.node_sound_stone_defaults()
+ })
+
+ default.register_fence(":default:fence_stone_brick", {
+ 	description = "Stone Brick Fence",
+ 	texture = "default_stone_brick.png",
+ 	material = "default:stonebrick",
+ 	groups = {cracky=2, stone=1},
+ 	sounds = default.node_sound_stone_defaults()
+ })
+
+ default.register_fence(":default:fence_sandstone_brick", {
+ 	description = "Sandstone Brick Fence",
+ 	texture = "default_sandstone_brick.png",
+ 	material = "default:sandstonebrick",
+ 	groups = {cracky=2},
+ 	sounds = default.node_sound_stone_defaults()
+ })
+
+ default.register_fence(":default:fence_desert_stone_brick", {
+ 	description = "Desert Stone Brick Fence",
+ 	texture = "default_desert_stone_brick.png",
+ 	material = "default:desert_stonebrick",
+ 	groups = {cracky=2, stone=1},
+ 	sounds = default.node_sound_stone_defaults()
+ })


### PR DESCRIPTION
Not entirely sure why, but it looks like some variations of fences were removed from default.
Causing much unknown nodes on the server.

This attempts to readd them, in craig_server. They weren't of much harm, and do add more content to build with. And a solution for all the unknown nodes rather than change them into other type of fences.