### PR TITLE
Fix: Bitcoin craft

### DIFF
--- a/mods/craig_server/craft_fix.lua
+++ b/mods/craig_server/craft_fix.lua
@@ -55,9 +55,8 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:gold_ingot 2',
+	output = 'default:gold_ingot',
 	recipe = {
-		{'bitchange:bitcoin', 'bitchange:bitcoin', 'bitchange:bitcoin'},
 		{'bitchange:bitcoin', 'bitchange:bitcoin', 'bitchange:bitcoin'},
 	}
 })

--- a/mods/craig_server/craft_fix.lua
+++ b/mods/craig_server/craft_fix.lua
@@ -45,3 +45,19 @@ minetest.register_craft({
 		{'default:gold_ingot', 'default:gold_ingot'},
 	}
 })
+
+minetest.register_craft({
+	output = 'bitchange:bitcoin 12',
+	recipe = {
+		{'default:gold_ingot', 'default:gold_ingot'},
+		{'default:gold_ingot', 'default:gold_ingot'},
+	}
+})
+
+minetest.register_craft({
+	output = 'default:gold_ingot 2',
+	recipe = {
+		{'bitchange:bitcoin', 'bitchange:bitcoin', 'bitchange:bitcoin'},
+		{'bitchange:bitcoin', 'bitchange:bitcoin', 'bitchange:bitcoin'},
+	}
+})


### PR DESCRIPTION
Looks like sometimes skeleton key overrides bitcoin rather than the other way round.
Also adds the ability to convert bitcoin back into gold.