### PR TITLE
Final increase for flower spread

### DIFF
--- a/mods/craig_server/old_flower_spread.lua
+++ b/mods/craig_server/old_flower_spread.lua
@@ -2,7 +2,7 @@ minetest.register_abm({
 	label = "Flower spread 2",
 	nodenames = {"group:flora"},
 	interval = 13,
-	chance = 96,
+	chance = 50,
 	action = function(pos, node)
 		pos.y = pos.y - 1
 		local under = minetest.get_node(pos)


### PR DESCRIPTION
Increase chance to spread.
Last change had a satisfactory result - except some flowers seem to not spread due to the high chance.
This attempts to half the chance, from 96 to 50. Should be the final change for flowers.