### PR TITLE
Feature: Add ability to craft silver sand from desert sand

### DIFF
--- a/mods/craig_server/craft_renewres.lua
+++ b/mods/craig_server/craft_renewres.lua
@@ -25,3 +25,10 @@ minetest.register_craft({
 		{'default:desert_cobble'},
 	}
 })
+
+minetest.register_craft({
+	output = 'default:silver_sand',
+	recipe = {
+		{'default:desert_sand'},
+	}
+})


### PR DESCRIPTION
Silver sand does not generate normally in v6 mapgen.
This adds a way to obtain it.