### PR TITLE
Add marble group to darkage marble

### DIFF
--- a/mods/darkage/nodes.lua
+++ b/mods/darkage/nodes.lua
@@ -12,7 +12,7 @@ minetest.register_node("darkage:marble", {
 	description = "Marble",
 	tiles = {"darkage_marble.png"},
 	is_ground_content = true,
-	groups = {cracky=3},
+	groups = {cracky=3,marble=1},
 	sounds = default.node_sound_stone_defaults()
 })
 


### PR DESCRIPTION
Homedecor uses the marble group to handle a lot of marble-based recipes.
This will allow darkage marble being used too rather than only building-blocks marbles.