### PR TITLE
Fix zoom

### DIFF
--- a/mods/craig_server/init.lua
+++ b/mods/craig_server/init.lua
@@ -43,3 +43,6 @@ dofile(minetest.get_modpath("craig_server").."/events.lua")
 
 -- Cloud height
 dofile(minetest.get_modpath("craig_server").."/cloud_height.lua")
+
+-- Zoom
+dofile(minetest.get_modpath("craig_server").."/zoom.lua")

--- a/mods/craig_server/zoom.lua
+++ b/mods/craig_server/zoom.lua
@@ -1,0 +1,3 @@
+minetest.register_on_joinplayer(function(player)
+    player:set_properties({zoom_fov = 15})
+end)


### PR DESCRIPTION
As of 0.5.0-dev, the zoom feature utilizes a player property than a privilege. It looks like player properties on the server aren't updated with the new zoom values.
This should force update the player zoom property and fix it.