### PR TITLE
Fix: Change mod_storage value to global

### DIFF
--- a/mods/craig_server/events.lua
+++ b/mods/craig_server/events.lua
@@ -1,5 +1,3 @@
-local mod_storage = minetest.get_mod_storage()
-
 -- Message of the day
 minetest.register_chatcommand("motd", {
 	description = "Message of the day.",

--- a/mods/craig_server/init.lua
+++ b/mods/craig_server/init.lua
@@ -1,6 +1,7 @@
 ---------------------
 -- Server Misc Mod --
 ---------------------
+mod_storage = minetest.get_mod_storage()
 
 -- Chat Commands
 dofile(minetest.get_modpath("craig_server").."/chatcommands.lua")

--- a/mods/craig_server/spawn.lua
+++ b/mods/craig_server/spawn.lua
@@ -1,6 +1,3 @@
--- Spawn command
-local mod_storage = minetest.get_mod_storage()
-
 minetest.register_chatcommand("spawn", {
     params = "",
     description = "Teleport to the spawn location.",


### PR DESCRIPTION
Looks like mod storage is only called once when the mod is located.
Causing the events/motd values to not be saved because they had another local mod storage value.
This should fix it.