### PR TITLE
Add HUD support for replacer and inspector tools.

### DIFF
--- a/mods/replacer/hud.lua
+++ b/mods/replacer/hud.lua
@@ -1,0 +1,32 @@
+-- HUD support added by lumberJack 
+
+-- store Hud ids by playername
+replacer.hud_ids = {};
+
+function replacer.set_hud(playername, message)
+    local player = minetest.get_player_by_name(playername)
+    if replacer.hud_ids[playername] ~= nil then
+        local id = replacer.hud_ids[playername]
+        player:hud_remove(id)
+    end
+
+    local id = player:hud_add({
+        hud_elem_type = "text",
+		name = "Replacer",
+		number = 0xFFFFFF,
+		position = {x=0.7, y=1},
+		offset = {x=0, y=-8},
+		text = message,
+		scale = {x=200, y=60},
+		alignment = {x=1, y=-1},
+
+    });
+
+    replacer.hud_ids[playername] = id;
+    
+    minetest.after(12, function()
+        if replacer.hud_ids[playername] == id then
+            player:hud_remove(id)
+        end
+    end);
+end

--- a/mods/replacer/hud.lua
+++ b/mods/replacer/hud.lua
@@ -30,3 +30,8 @@ function replacer.set_hud(playername, message)
         end
     end);
 end
+
+minetest.register_on_leaveplayer(function(player, timed_out)
+    local name = player:get_player_name()
+    replacer.hud_ids[name] = nil
+end)

--- a/mods/replacer/init.lua
+++ b/mods/replacer/init.lua
@@ -57,6 +57,8 @@ replacer.blacklist[ "protector:protect2"] = true;
 
 -- adds a tool for inspecting nodes and entities
 dofile(minetest.get_modpath("replacer").."/inspect.lua");
+-- add HUD support for tool information
+dofile(minetest.get_modpath("replacer").."/hud.lua")
 
 minetest.register_tool( "replacer:replacer",
 {
@@ -100,7 +102,8 @@ minetest.register_tool( "replacer:replacer",
 
  
        if( pointed_thing.type ~= "node" ) then
-          minetest.chat_send_player( name, "  Error: No node selected.");
+         -- minetest.chat_send_player( name, "  Error: No node selected.");
+          replacer.set_hud(name, "  Error: No node selected.");
           return nil;
        end
 
@@ -114,8 +117,8 @@ minetest.register_tool( "replacer:replacer",
        end
        itemstack:set_metadata( metadata );
 
-       minetest.chat_send_player( name, "Node replacement tool set to: '"..metadata.."'.");
-
+       --minetest.chat_send_player( name, "Node replacement tool set to: '"..metadata.."'.");
+       replacer.set_hud(name, "Node replacement tool set to: '"..metadata.."'.");
        return itemstack; -- nothing consumed but data changed
     end,
      
@@ -138,7 +141,8 @@ replacer.replace = function( itemstack, user, pointed_thing, mode )
        --minetest.chat_send_player( name, "You USED this on "..minetest.serialize( pointed_thing )..".");
  
        if( pointed_thing.type ~= "node" ) then
-          minetest.chat_send_player( name, "  Error: No node.");
+          --minetest.chat_send_player( name, "  Error: No node.");
+          replacer.set_hud(name, "  Error: No node.");
           return nil;
        end
 
@@ -149,7 +153,8 @@ replacer.replace = function( itemstack, user, pointed_thing, mode )
 
        if( node == nil ) then
 
-          minetest.chat_send_player( name, "Error: Target node not yet loaded. Please wait a moment for the server to catch up.");
+          --minetest.chat_send_player( name, "Error: Target node not yet loaded. Please wait a moment for the server to catch up.");
+          replacer.set_hud(name, "Error: Target node not yet loaded. Please wait a moment for the server to catch up.");
           return nil;
        end
 
@@ -176,14 +181,18 @@ replacer.replace = function( itemstack, user, pointed_thing, mode )
        end
 
        if( node.name and node.name ~= "" and replacer.blacklist[ node.name ]) then
-          minetest.chat_send_player( name, "Replacing blocks of the type '"..( node.name or "?" )..
-		"' is not allowed on this server. Replacement failed.");
-          return nil;
+          --minetest.chat_send_player( name, "Replacing blocks of the type '"..( node.name or "?" )..
+		--"' is not allowed on this server. Replacement failed.");
+          replacer.set_hud( name, "Replacing blocks of the type '"..( node.name or "?" )..
+		    "' is not allowed on this server. Replacement failed.");
+         return nil;
        end
 
        if( replacer.blacklist[ daten[1] ]) then
-          minetest.chat_send_player( name, "Placing blocks of the type '"..( daten[1] or "?" )..
-		"' with the replacer is not allowed on this server. Replacement failed.");
+         -- minetest.chat_send_player( name, "Placing blocks of the type '"..( daten[1] or "?" )..
+      --"' with the replacer is not allowed on this server. Replacement failed.");
+          replacer.set_hud( name, "Placing blocks of the type '"..( daten[1] or "?" )..
+		    "' with the replacer is not allowed on this server. Replacement failed.");
           return nil;
        end
 
@@ -214,7 +223,8 @@ replacer.replace = function( itemstack, user, pointed_thing, mode )
           if( not( user:get_inventory():contains_item("main", daten[1]))) then
  
 
-             minetest.chat_send_player( name, "You have no further '"..( daten[1] or "?" ).."'. Replacement failed.");
+             --minetest.chat_send_player( name, "You have no further '"..( daten[1] or "?" ).."'. Replacement failed.");
+             replacer.set_hud(name, "You have no further '"..( daten[1] or "?" ).."'. Replacement failed.");
              return nil;
           end
 
@@ -236,7 +246,8 @@ replacer.replace = function( itemstack, user, pointed_thing, mode )
              if( not( digged_node ) 
                 or digged_node.name == node.name ) then
 
-                minetest.chat_send_player( name, "Replacing '"..( node.name or "air" ).."' with '"..( item[ "metadata"] or "?" ).."' failed. Unable to remove old node.");
+                --minetest.chat_send_player( name, "Replacing '"..( node.name or "air" ).."' with '"..( item[ "metadata"] or "?" ).."' failed. Unable to remove old node.");
+                replacer.set_hud(name, "Replacing '"..( node.name or "air" ).."' with '"..( item[ "metadata"] or "?" ).."' failed. Unable to remove old node.");
                 return nil;
              end
             

--- a/mods/replacer/inspect.lua
+++ b/mods/replacer/inspect.lua
@@ -93,10 +93,10 @@ replacer.inspect = function( itemstack, user, pointed_thing, mode, show_receipe 
 
 		end
 		text = text..' at '..minetest.pos_to_string( ref:get_pos() );
-		minetest.chat_send_player( name, text );
+		replacer.set_hud( name, text );
 		return nil;
 	elseif( pointed_thing.type ~= 'node' ) then
-		minetest.chat_send_player( name, 'Sorry. This is an unkown something of type \"'..tostring( pointed_thing.type )..'\". No information available.');
+		replacer.set_hud( name, 'Sorry. This is an unkown something of type \"'..tostring( pointed_thing.type )..'\". No information available.');
 		return nil;
 	end
 	
@@ -104,7 +104,7 @@ replacer.inspect = function( itemstack, user, pointed_thing, mode, show_receipe 
 	local node = minetest.get_node_or_nil( pos );
        
 	if( node == nil ) then
-		minetest.chat_send_player( name, "Error: Target node not yet loaded. Please wait a moment for the server to catch up.");
+		replacer.set_hud( name, "Error: Target node not yet loaded. Please wait a moment for the server to catch up.");
 		return nil;
 	end
 


### PR DESCRIPTION
Hey Craig, just a fairly simple PR for quality of life with the replacer and inspector tools. This adds a text HUD to the bottom right (opposite of Areas) that gives status updates instead of spamming the chat. HUD messages time out after a few seconds and are removed. Changes have been tested locally. Thanks!